### PR TITLE
Fix PushContainer  handle calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/*.rs.bk
 
 .idea
+.vscode
 
 # Temporary directory for debug data storage
 /data

--- a/src/downpourd/service.rs
+++ b/src/downpourd/service.rs
@@ -145,6 +145,10 @@ impl Runtime {
                 )?;
             }
 
+            ExtMsg::ContainerRetrieved(_) => {
+                warn!("No active action is known for this message")
+            }
+
             wrong_msg => {
                 error!("Request is not supported by the Storm interface");
                 return Err(DaemonError::wrong_esb_msg(ServiceBus::Rpc, &wrong_msg));

--- a/src/transferd/automation.rs
+++ b/src/transferd/automation.rs
@@ -196,6 +196,14 @@ impl Runtime {
 
         debug!("Requesting {} chunks", chunk_ids.len());
         trace!("Requested chunk ids: {:?}", chunk_ids);
+
+        // Switching the state
+        self.state = State::Receive(ReceiveState::ReceivingChunks {
+            info,
+            total: unknown_count,
+            pending: chunk_ids.clone(),
+        });
+
         self.send_p2p(
             endpoints,
             info.remote_id,
@@ -206,13 +214,6 @@ impl Runtime {
                 chunk_ids: chunk_ids.clone(),
             }),
         )?;
-
-        // Switching the state
-        self.state = State::Receive(ReceiveState::ReceivingChunks {
-            info,
-            total: unknown_count,
-            pending: chunk_ids,
-        });
 
         Ok(())
     }


### PR DESCRIPTION
**Description**

After receiving the consignment file, the **transferd daemon** calls `handle_container` directly, causing an _InvalidState_ error because the state has _Free_ instead of _AwaitingContainer_ .

To solve that, I changed the PushContainer handle in two steps:

1. If StormApp is **RgbTransfers**, the transferd calls  `handle_container`
2. If StormApp is **FileTransfer**, the transferd calls  `handle_container`

After changes, the daemon started to store the consignment file.