### PR TITLE
update clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,16 +397,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -414,18 +414,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "3.1.4"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da92e6facd8d73c22745a5d3cbb59bdf8e46e3235c923e516527d8e81eec14a4"
+checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.1.18"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -2249,9 +2249,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ chrono = "0.4"
 nix = "0.24"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 env_logger = "0.7"
-clap = { version = "~3.1.18", optional = true, features = ["env", "derive"] }
+clap = { version = "~3.2.23", optional = true, features = ["env", "derive"] }
 settings = { version = "0.10", package = "config", optional = true }
 configure_me = { version = "0.4", optional = true }
 dotenv = { version = "0.15", optional = true }
@@ -68,8 +68,8 @@ microservices = { version = "0.8.0", default-features = false, features = ["node
 storm_ext = { version = "0.8.0", path = "ext" }
 storm_rpc = { version = "0.8.0", path = "rpc" }
 store_rpc = "0.8.0"
-clap = { version = "~3.1.18", features = ["env", "derive"] }
-clap_complete = "~3.1.4"
+clap = { version = "~3.2.23", features = ["env", "derive"] }
+clap_complete = "~3.2.5"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 shellexpand = "2"
 configure_me_codegen = "0.4"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,7 +27,7 @@ store_rpc = "0.8.0"
 lnp-core = "0.8.0"
 lnp_rpc = "0.8.0"
 shellexpand = "2.1"
-clap = { version = "~3.1.18", features = ["derive", "env"] }
+clap = { version = "~3.2.23", features = ["derive", "env"] }
 log = "0.4.14"
 colored = "2"
 
@@ -39,6 +39,6 @@ storm_rpc = { version = "0.8.0", path = "../rpc" }
 store_rpc = "0.8.0"
 lnp_rpc = "0.8.0"
 internet2 = "0.8.0"
-clap = { version = "~3.1.18", features = ["derive", "env"] }
-clap_complete = "~3.1.4"
+clap = { version = "~3.2.23", features = ["derive", "env"] }
+clap_complete = "~3.2.5"
 configure_me_codegen = "0.4"


### PR DESCRIPTION
after rgb-node 0.8.4 and rgb-std 0.8.2 releases storm-node has a dependency conflict with clap. this PR fixes the conflict by updating clap. 

@dr-orlovsky if this seems ok to you could you please merge it and release storm-node 0.8.1? Could you also backport to the `v0.8` branch any other fix/feature that's been added to `master`?